### PR TITLE
fix: remove a few compile errors

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -17,5 +17,5 @@ pub fn size() -> Option<(Width, Height)> {
 
 #[cfg(not(windows))]
 pub fn size() -> Option<(Width, Height)> {
-  terimnal_size::terminal_size_using_fd(rustix::io::raw_stderr())
+  terminal_size::terminal_size_using_fd(rustix::io::raw_stderr())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,13 +125,13 @@ impl ConsoleStaticText {
     if !atty::is(atty::Stream::Stderr) || console::size().is_none() {
       None
     } else {
-      Self::new(|| {
+      Some(Self::new(|| {
         let size = console::size();
         ConsoleSize {
           cols: size.map(|s| s.0 .0),
           rows: size.map(|s| s.1 .0),
         }
-      })
+      }))
     }
   }
 


### PR DESCRIPTION
Fixes two small compile errors in the Console Static Text.
1. A misspelled module name
2. A missing Options::Some wrapping around the return value in a function.