### PR TITLE
Add a CI job to Console Static Text

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: Cargo Build & Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build_and_test:
+    name: Build & Test Console Static Text
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup update stable && rustup default stable
+      - run: cargo build --verbose --all-features
+      - run: cargo test --verbose --all-features

--- a/src/word.rs
+++ b/src/word.rs
@@ -1,3 +1,4 @@
+#[derive(PartialEq, Debug)]
 pub enum WordToken<'a> {
   Word(&'a str),
   WhiteSpace(char),
@@ -29,4 +30,101 @@ pub fn tokenize_words(text: &str) -> Vec<WordToken> {
     tokens.push(WordToken::Word(new_word_text));
   }
   tokens
+}
+
+#[cfg(test)]
+mod tokenize_tests {
+  use super::*;
+
+  #[test]
+  fn tokenize_words_2_words() {
+    let result = tokenize_words("hello world");
+    assert_eq!(
+      result,
+      vec![
+        WordToken::Word("hello"),
+        WordToken::WhiteSpace(' '),
+        WordToken::Word("world")
+      ]
+    );
+  }
+
+  #[test]
+  fn tokenize_words_newline() {
+    let result = tokenize_words("hello\nworld");
+    assert_eq!(
+      result,
+      vec![
+        WordToken::Word("hello"),
+        WordToken::NewLine,
+        WordToken::Word("world")
+      ]
+    );
+  }
+
+  #[test]
+  fn tokenize_words_newline_spaces() {
+    let result = tokenize_words("hello \n world");
+    assert_eq!(
+      result,
+      vec![
+        WordToken::Word("hello"),
+        WordToken::WhiteSpace(' '),
+        WordToken::NewLine,
+        WordToken::WhiteSpace(' '),
+        WordToken::Word("world")
+      ]
+    );
+  }
+
+  #[test]
+  fn tokenize_words_tab_char() {
+    let result = tokenize_words("hello\tworld");
+    assert_eq!(
+      result,
+      vec![
+        WordToken::Word("hello"),
+        WordToken::WhiteSpace('\t'),
+        WordToken::Word("world")
+      ]
+    );
+  }
+
+  #[test]
+  fn tokenize_words_single_word() {
+    let result = tokenize_words("hello");
+    assert_eq!(result, vec![WordToken::Word("hello"),]);
+  }
+
+  #[test]
+  fn tokenize_words_leading_trailing_whitespace() {
+    let result = tokenize_words(" hello ");
+    assert_eq!(
+      result,
+      vec![
+        WordToken::WhiteSpace(' '),
+        WordToken::Word("hello"),
+        WordToken::WhiteSpace(' ')
+      ]
+    );
+  }
+
+  #[test]
+  fn tokenize_words_with_rune_character() {
+    let result = tokenize_words("hello⌘ ⌘world");
+    assert_eq!(
+      result,
+      vec![
+        WordToken::Word("hello⌘"),
+        WordToken::WhiteSpace(' '),
+        WordToken::Word("⌘world")
+      ]
+    );
+  }
+
+  #[test]
+  fn tokenize_words_single_rune_character() {
+    let result = tokenize_words("⌘");
+    assert_eq!(result, vec![WordToken::Word("⌘"),]);
+  }
 }


### PR DESCRIPTION
Adds a GitHub Actions job to run the build & tests on every push. The project is built with all feature flag enabled.

This change-set also adds a variety of test cases for the tokenizer in `words.rs`. To make testing easier, the `PartialEq` and `Debug` debug traits were added to the `WordToken` enum.

A few notes:
- I'm more familiar with the GitLab syntax, so there may be better way to structure this file. I followed the examples at [1].
- I added a few traits to `WordToken` to help with testing. I'm not sure if this will add any unacceptable overhead. I mentioned this in the commit message.

[1] https://doc.rust-lang.org/cargo/guide/continuous-integration.html