### PR TITLE
perf: handle many text items or large text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,6 +50,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+ "terminal_size",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "condtype"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
+
+[[package]]
 name = "console"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +101,7 @@ dependencies = [
  "atty",
  "console",
  "crossterm",
+ "divan",
  "pretty_assertions",
  "rustix",
  "terminal_size",
@@ -103,7 +142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -111,6 +150,31 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "divan"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a405457ec78b8fe08b0e32b4a3570ab5dff6dd16eb9e76a5ee0a9d9cbd898933"
+dependencies = [
+ "cfg-if",
+ "clap",
+ "condtype",
+ "divan-macros",
+ "libc",
+ "regex-lite",
+]
+
+[[package]]
+name = "divan-macros"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9556bc800956545d6420a640173e5ba7dfa82f38d3ea5a167eb555bc69ac3323"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -232,18 +296,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -256,6 +320,12 @@ checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags 1.3.2",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "rustix"
@@ -317,6 +387,17 @@ name = "syn"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,9 @@ windows-sys = { version = "0.52.0", features = ["Win32_Foundation", "Win32_Syste
 [dev-dependencies]
 console = "0.15.7"
 crossterm = "0.27.0"
+divan = "0.1"
 pretty_assertions = "1.3"
+
+[[bench]]
+name = "render"
+harness = false

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2022-2023 David Sherret
+Copyright (c) 2022 David Sherret
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/benches/render.rs
+++ b/benches/render.rs
@@ -42,6 +42,20 @@ fn single_item_many_paragraphs(bencher: divan::Bencher, n: usize) {
   });
 }
 
+// A single item containing one very long unbroken word. Exercises the
+// long-word per-char break path; only the bottom 25 wrapped lines should
+// survive, but every char above must still be examined to know where to
+// break.
+#[divan::bench(args = [80, 800, 8_000, 80_000])]
+fn single_long_line(bencher: divan::Bencher, len: usize) {
+  let text: String = std::iter::repeat('x').take(len).collect();
+  let items = [TextItem::new_owned(text)];
+  bencher.bench_local(|| {
+    let mut s = ConsoleStaticText::new(|| SIZE);
+    s.render_items_with_size(divan::black_box(items.iter()), SIZE)
+  });
+}
+
 // Items that need word wrapping — exercises the per-word path that previously
 // allocated a `Vec<AnsiToken>` for every word.
 #[divan::bench(args = [25, 100, 1_000])]

--- a/benches/render.rs
+++ b/benches/render.rs
@@ -1,0 +1,61 @@
+use console_static_text::ConsoleSize;
+use console_static_text::ConsoleStaticText;
+use console_static_text::TextItem;
+
+fn main() {
+  divan::main();
+}
+
+const COLS: u16 = 80;
+const ROWS: u16 = 25;
+
+const SIZE: ConsoleSize = ConsoleSize {
+  cols: Some(COLS),
+  rows: Some(ROWS),
+};
+
+// Render thousands of small text items into a 25-row console — the bottom-up
+// item walk should keep work proportional to the visible window, not N.
+#[divan::bench(args = [25, 100, 1_000, 10_000])]
+fn many_items(bencher: divan::Bencher, n: usize) {
+  let items: Vec<TextItem<'static>> = (0..n)
+    .map(|i| TextItem::new_owned(format!("item line {}", i)))
+    .collect();
+  bencher.bench_local(|| {
+    let mut s = ConsoleStaticText::new(|| SIZE);
+    s.render_items_with_size(divan::black_box(items.iter()), SIZE)
+  });
+}
+
+// Single text item with many newline-separated paragraphs — the
+// paragraph-level bottom-up pass should skip wrapping for invisible ones.
+#[divan::bench(args = [25, 100, 1_000, 10_000])]
+fn single_item_many_paragraphs(bencher: divan::Bencher, n: usize) {
+  let text = (0..n)
+    .map(|i| format!("paragraph {}", i))
+    .collect::<Vec<_>>()
+    .join("\n");
+  let items = [TextItem::new_owned(text)];
+  bencher.bench_local(|| {
+    let mut s = ConsoleStaticText::new(|| SIZE);
+    s.render_items_with_size(divan::black_box(items.iter()), SIZE)
+  });
+}
+
+// Items that need word wrapping — exercises the per-word path that previously
+// allocated a `Vec<AnsiToken>` for every word.
+#[divan::bench(args = [25, 100, 1_000])]
+fn wrapped_items(bencher: divan::Bencher, n: usize) {
+  let items: Vec<TextItem<'static>> = (0..n)
+    .map(|i| {
+      TextItem::new_owned(format!(
+        "this is a moderately long line {} that needs wrapping at eighty columns to exercise the word wrapping path",
+        i
+      ))
+    })
+    .collect();
+  bencher.bench_local(|| {
+    let mut s = ConsoleStaticText::new(|| SIZE);
+    s.render_items_with_size(divan::black_box(items.iter()), SIZE)
+  });
+}

--- a/dprint.json
+++ b/dprint.json
@@ -8,9 +8,9 @@
   },
   "excludes": ["target/"],
   "plugins": [
-    "https://plugins.dprint.dev/toml-0.5.4.wasm",
-    "https://plugins.dprint.dev/exec-0.4.4.json@c207bf9b9a4ee1f0ecb75c594f774924baf62e8e53a2ce9d873816a408cecbf7",
-    "https://plugins.dprint.dev/json-0.17.1.wasm",
-    "https://plugins.dprint.dev/markdown-0.15.2.wasm"
+    "https://plugins.dprint.dev/toml-0.7.0.wasm",
+    "https://plugins.dprint.dev/exec-0.6.2.json@df98f54ffd3092b8a841aedd6d098a2651f16d0a796a40535774f1a8b4b9d463",
+    "https://plugins.dprint.dev/json-0.21.3.wasm",
+    "https://plugins.dprint.dev/markdown-0.21.1.wasm"
   ]
 }

--- a/dprint.json
+++ b/dprint.json
@@ -1,7 +1,8 @@
 {
   "exec": {
+    "cwd": "${configDir}",
     "commands": [{
-      "command": "rustfmt --edition 2021 --config imports_granularity=item",
+      "command": "rustfmt --edition 2024 --config imports_granularity=item",
       "exts": ["rs"]
     }]
   },

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -10,6 +10,10 @@ pub struct AnsiToken {
 }
 
 pub fn strip_ansi_codes(text: &str) -> Cow<'_, str> {
+  // fast path: no escape byte means no parser work and no allocation
+  if !text.as_bytes().contains(&0x1b) {
+    return Cow::Borrowed(text);
+  }
   let tokens = tokenize(text);
   if tokens.is_empty() || tokens.len() == 1 && !tokens[0].is_escape {
     Cow::Borrowed(text)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -560,10 +560,8 @@ fn wrap_paragraph<'a>(
               {
                 if line_width + char_width > terminal_width {
                   if byte_pos > seg_start {
-                    current_line.push_segment(
-                      &chunk[seg_start..byte_pos],
-                      seg_width,
-                    );
+                    current_line
+                      .push_segment(&chunk[seg_start..byte_pos], seg_width);
                   }
                   lines.push(std::mem::replace(
                     &mut current_line,
@@ -579,8 +577,7 @@ fn wrap_paragraph<'a>(
               byte_pos += c_len;
             }
             if byte_pos > seg_start {
-              current_line
-                .push_segment(&chunk[seg_start..byte_pos], seg_width);
+              current_line.push_segment(&chunk[seg_start..byte_pos], seg_width);
             }
           }
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,53 @@ impl Line {
   }
 }
 
+// A line described as a sequence of borrowed segments from the source text
+// plus a hanging-indent prefix. We defer allocating the final `String` until
+// we know the line will actually be displayed — items above the console
+// height, or paragraphs above a tall item's visible window, never pay the
+// concatenation cost.
+struct PendingLine<'a> {
+  indent: usize,
+  segments: Vec<&'a str>,
+  total_bytes: usize,
+  char_width: usize,
+}
+
+impl<'a> PendingLine<'a> {
+  fn new(indent: usize) -> Self {
+    Self {
+      indent,
+      segments: Vec::new(),
+      total_bytes: 0,
+      char_width: indent,
+    }
+  }
+
+  fn push_segment(&mut self, s: &'a str, visible_width: usize) {
+    self.segments.push(s);
+    self.total_bytes += s.len();
+    self.char_width += visible_width;
+  }
+
+  fn into_line(self) -> Line {
+    let mut text = String::with_capacity(self.indent + self.total_bytes);
+    for _ in 0..self.indent {
+      text.push(' ');
+    }
+    for seg in self.segments {
+      text.push_str(seg);
+    }
+    Line {
+      char_width: self.char_width,
+      text,
+    }
+  }
+
+  fn has_content(&self) -> bool {
+    !self.segments.is_empty() || self.indent > 0
+  }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ConsoleSize {
   pub cols: Option<u16>,
@@ -210,14 +257,14 @@ impl ConsoleStaticText {
 
   pub fn eprint_items<'a>(
     &mut self,
-    text_items: impl Iterator<Item = &'a TextItem<'a>>,
+    text_items: impl DoubleEndedIterator<Item = &'a TextItem<'a>>,
   ) -> std::io::Result<()> {
     self.eprint_items_with_size(text_items, self.console_size())
   }
 
   pub fn eprint_items_with_size<'a>(
     &mut self,
-    text_items: impl Iterator<Item = &'a TextItem<'a>>,
+    text_items: impl DoubleEndedIterator<Item = &'a TextItem<'a>>,
     size: ConsoleSize,
   ) -> std::io::Result<()> {
     if let Some(text) = self.render_items_with_size(text_items, size) {
@@ -228,27 +275,29 @@ impl ConsoleStaticText {
 
   pub fn render_items<'a>(
     &mut self,
-    text_items: impl Iterator<Item = &'a TextItem<'a>>,
+    text_items: impl DoubleEndedIterator<Item = &'a TextItem<'a>>,
   ) -> Option<String> {
     self.render_items_with_size(text_items, self.console_size())
   }
 
   pub fn render_items_with_size<'a>(
     &mut self,
-    text_items: impl Iterator<Item = &'a TextItem<'a>>,
+    text_items: impl DoubleEndedIterator<Item = &'a TextItem<'a>>,
     size: ConsoleSize,
   ) -> Option<String> {
     let is_terminal_different_size = size != self.last_size;
     let last_lines = self.get_last_lines(size);
     let new_lines = render_items(text_items, size);
-    let last_lines_for_new_lines = raw_render_last_items(
-      &new_lines
-        .iter()
-        .map(|l| l.text.as_str())
-        .collect::<Vec<_>>()
-        .join("\n"),
-      size,
-    );
+    // new_lines are already wrapped to the terminal width and truncated
+    // to the height by render_items, so we only need to ANSI-strip the
+    // text to mirror what raw_render_last_items would produce.
+    let last_lines_for_new_lines: Vec<Line> = new_lines
+      .iter()
+      .map(|line| Line {
+        char_width: line.char_width,
+        text: strip_ansi_codes(&line.text).into_owned(),
+      })
+      .collect();
     let result =
       if !are_collections_equal(&last_lines, &last_lines_for_new_lines) {
         let mut text = String::new();
@@ -290,7 +339,7 @@ impl ConsoleStaticText {
 
   fn get_last_lines(&mut self, size: ConsoleSize) -> Vec<Line> {
     if size == self.last_size {
-      self.last_lines.drain(..).collect()
+      std::mem::take(&mut self.last_lines)
     } else {
       // render the last text with the current terminal width
       let line_texts = self
@@ -340,27 +389,47 @@ fn raw_render_last_items(text: &str, size: ConsoleSize) -> Vec<Line> {
 }
 
 fn render_items<'a>(
-  text_items: impl Iterator<Item = &'a TextItem<'a>>,
+  text_items: impl DoubleEndedIterator<Item = &'a TextItem<'a>>,
   size: ConsoleSize,
 ) -> Vec<Line> {
-  let mut lines = Vec::new();
   let terminal_width = size.cols.map(|c| c as usize);
-  for item in text_items {
-    match item {
-      TextItem::Text(text) => {
-        lines.extend(render_text_to_lines(text, 0, terminal_width))
-      }
+  let terminal_height = size.rows.map(|c| c as usize);
+
+  // process items bottom-up so thousands of text items don't force
+  // rendering work we'd immediately truncate away. accumulate lines
+  // in reverse, stopping once we've filled the console height.
+  let mut iter = text_items.rev().peekable();
+  let mut rev_lines: Vec<Line> = match terminal_height {
+    Some(h) if iter.peek().is_some() => Vec::with_capacity(h),
+    _ => Vec::new(),
+  };
+  'outer: for item in iter {
+    if let Some(h) = terminal_height
+      && rev_lines.len() >= h
+    {
+      break;
+    }
+    let (text, indent) = match item {
+      TextItem::Text(text) => (text.as_ref(), 0usize),
       TextItem::HangingText { text, indent } => {
-        lines.extend(render_text_to_lines(
-          text,
-          *indent as usize,
-          terminal_width,
-        ));
+        (text.as_ref(), *indent as usize)
+      }
+    };
+    let remaining = terminal_height.map(|h| h - rev_lines.len());
+    let pending =
+      render_text_to_pending(text, indent, terminal_width, remaining);
+    for pl in pending.into_iter().rev() {
+      rev_lines.push(pl.into_line());
+      if let Some(h) = terminal_height
+        && rev_lines.len() >= h
+      {
+        break 'outer;
       }
     }
   }
+  rev_lines.reverse();
+  let lines = rev_lines;
 
-  let lines = truncate_lines_height(lines, size);
   // ensure there's always 1 line
   if lines.is_empty() {
     vec![Line::new(String::new())]
@@ -369,110 +438,190 @@ fn render_items<'a>(
   }
 }
 
-fn truncate_lines_height(lines: Vec<Line>, size: ConsoleSize) -> Vec<Line> {
-  match size.rows.map(|c| c as usize) {
-    Some(terminal_height) if lines.len() > terminal_height => {
-      let cutoff_index = lines.len() - terminal_height;
-      lines
-        .into_iter()
-        .enumerate()
-        .filter_map(|(index, line)| {
-          if index < cutoff_index {
-            None
-          } else {
-            Some(line)
+fn truncate_lines_height(mut lines: Vec<Line>, size: ConsoleSize) -> Vec<Line> {
+  if let Some(terminal_height) = size.rows.map(|c| c as usize)
+    && lines.len() > terminal_height
+  {
+    let cutoff_index = lines.len() - terminal_height;
+    lines.drain(..cutoff_index);
+  }
+  lines
+}
+
+// Produces pending lines for a single text item, processing paragraphs
+// (newline-delimited segments) bottom-up and stopping once `max_lines` is
+// satisfied. This means early paragraphs of a tall item are never word-wrapped
+// if they'd be truncated away anyway.
+fn render_text_to_pending<'a>(
+  text: &'a str,
+  hanging_indent: usize,
+  terminal_width: Option<usize>,
+  max_lines: Option<usize>,
+) -> Vec<PendingLine<'a>> {
+  if text.is_empty() || max_lines == Some(0) {
+    return Vec::new();
+  }
+
+  let paragraphs: Vec<&'a str> = text.split_terminator('\n').collect();
+  // paragraph i was preceded by `\n` in the source when i > 0; when it's a
+  // middle/early paragraph the trailing `\r` belongs to a CRLF pair and must
+  // be trimmed so it doesn't leak into the rendered line
+  let paragraph_at = |i: usize| -> &'a str {
+    let p = paragraphs[i];
+    if i + 1 < paragraphs.len() {
+      p.strip_suffix('\r').unwrap_or(p)
+    } else {
+      p
+    }
+  };
+
+  match terminal_width {
+    None => {
+      // no wrapping — each paragraph is exactly one line
+      let start =
+        max_lines.map_or(0, |max| paragraphs.len().saturating_sub(max));
+      (start..paragraphs.len())
+        .map(|i| {
+          let p = paragraph_at(i);
+          let width = UnicodeWidthStr::width(strip_ansi_codes(p).as_ref());
+          let mut pl = PendingLine::new(0);
+          if !p.is_empty() {
+            pl.push_segment(p, width);
           }
+          pl
         })
         .collect()
     }
-    _ => lines,
+    Some(terminal_width) => {
+      let mut result: Vec<PendingLine<'a>> = Vec::new();
+      'outer: for i in (0..paragraphs.len()).rev() {
+        let p = paragraph_at(i);
+        let mut paragraph_lines =
+          wrap_paragraph(p, hanging_indent, terminal_width);
+        if paragraph_lines.is_empty() {
+          // an empty or whitespace-only paragraph still occupies one line
+          paragraph_lines.push(PendingLine::new(0));
+        }
+        for pl in paragraph_lines.into_iter().rev() {
+          result.push(pl);
+          if let Some(max) = max_lines
+            && result.len() >= max
+          {
+            break 'outer;
+          }
+        }
+      }
+      result.reverse();
+      result
+    }
   }
 }
 
-fn render_text_to_lines(
-  text: &str,
+fn wrap_paragraph<'a>(
+  text: &'a str,
   hanging_indent: usize,
-  terminal_width: Option<usize>,
-) -> Vec<Line> {
-  let mut lines = Vec::new();
-  if let Some(terminal_width) = terminal_width {
-    let mut current_line = String::new();
-    let mut line_width = 0;
-    let mut current_whitespace = String::new();
-    for token in tokenize_words(text) {
-      match token {
-        WordToken::Word(word) => {
-          let word_width =
-            UnicodeWidthStr::width(strip_ansi_codes(word).as_ref());
-          let is_word_longer_than_half_line =
-            hanging_indent + word_width > (terminal_width / 2);
-          if is_word_longer_than_half_line {
-            // break it up onto multiple lines with indentation if able
-            if !current_whitespace.is_empty() {
-              if line_width < terminal_width {
-                current_line.push_str(&current_whitespace);
-              }
-              current_whitespace = String::new();
-            }
-            for ansi_token in ansi::tokenize(word) {
-              if ansi_token.is_escape {
-                current_line.push_str(&word[ansi_token.range]);
-              } else {
-                for c in word[ansi_token.range].chars() {
-                  if let Some(char_width) =
-                    unicode_width::UnicodeWidthChar::width(c)
-                  {
-                    if line_width + char_width > terminal_width {
-                      lines.push(Line::new(current_line));
-                      current_line = String::new();
-                      current_line.push_str(&" ".repeat(hanging_indent));
-                      line_width = hanging_indent;
-                    }
-                    current_line.push(c);
-                    line_width += char_width;
-                  } else {
-                    current_line.push(c);
-                  }
-                }
-              }
-            }
-          } else {
-            if line_width + word_width > terminal_width {
-              lines.push(Line::new(current_line));
-              current_line = String::new();
-              current_line.push_str(&" ".repeat(hanging_indent));
-              line_width = hanging_indent;
-              current_whitespace = String::new();
-            }
-            if !current_whitespace.is_empty() {
-              current_line.push_str(&current_whitespace);
-              current_whitespace = String::new();
-            }
-            current_line.push_str(word);
-            line_width += word_width;
+  terminal_width: usize,
+) -> Vec<PendingLine<'a>> {
+  let mut lines: Vec<PendingLine<'a>> = Vec::new();
+  let mut current_line = PendingLine::new(0);
+  let mut line_width: usize = 0;
+  let mut pending_whitespace: Option<&'a str> = None;
+
+  for token in tokenize_words(text) {
+    match token {
+      WordToken::Word(word) => {
+        let word_width =
+          UnicodeWidthStr::width(strip_ansi_codes(word).as_ref());
+        let is_word_longer_than_half_line =
+          hanging_indent + word_width > (terminal_width / 2);
+        if is_word_longer_than_half_line {
+          // flush pending whitespace if it still fits on the line
+          if let Some(ws) = pending_whitespace.take()
+            && line_width < terminal_width
+          {
+            let ws_width = visible_whitespace_width(ws);
+            current_line.push_segment(ws, ws_width);
           }
-        }
-        WordToken::WhiteSpace(space_char) => {
-          current_whitespace.push(space_char);
-          line_width +=
-            unicode_width::UnicodeWidthChar::width(space_char).unwrap_or(1);
-        }
-        WordToken::LfNewLine | WordToken::CrlfNewLine => {
-          lines.push(Line::new(current_line));
-          current_line = String::new();
-          line_width = 0;
+          // break the word at char boundaries across multiple lines,
+          // preserving ANSI escapes as zero-width segments
+          for ansi_token in ansi::tokenize(word) {
+            let chunk = &word[ansi_token.range.clone()];
+            if ansi_token.is_escape {
+              current_line.push_segment(chunk, 0);
+              continue;
+            }
+            let mut seg_start = 0;
+            let mut seg_width = 0;
+            let mut byte_pos = 0;
+            for c in chunk.chars() {
+              let c_len = c.len_utf8();
+              if let Some(char_width) =
+                unicode_width::UnicodeWidthChar::width(c)
+              {
+                if line_width + char_width > terminal_width {
+                  if byte_pos > seg_start {
+                    current_line.push_segment(
+                      &chunk[seg_start..byte_pos],
+                      seg_width,
+                    );
+                  }
+                  lines.push(std::mem::replace(
+                    &mut current_line,
+                    PendingLine::new(hanging_indent),
+                  ));
+                  line_width = hanging_indent;
+                  seg_start = byte_pos;
+                  seg_width = 0;
+                }
+                line_width += char_width;
+                seg_width += char_width;
+              }
+              byte_pos += c_len;
+            }
+            if byte_pos > seg_start {
+              current_line
+                .push_segment(&chunk[seg_start..byte_pos], seg_width);
+            }
+          }
+        } else {
+          if line_width + word_width > terminal_width {
+            lines.push(std::mem::replace(
+              &mut current_line,
+              PendingLine::new(hanging_indent),
+            ));
+            line_width = hanging_indent;
+            pending_whitespace = None;
+          }
+          if let Some(ws) = pending_whitespace.take() {
+            let ws_width = visible_whitespace_width(ws);
+            current_line.push_segment(ws, ws_width);
+          }
+          current_line.push_segment(word, word_width);
+          line_width += word_width;
         }
       }
-    }
-    if !current_line.is_empty() {
-      lines.push(Line::new(current_line));
-    }
-  } else {
-    for line in text.split('\n') {
-      lines.push(Line::new(line.to_string()));
+      WordToken::WhiteSpace(ws) => {
+        pending_whitespace = Some(ws);
+        line_width += visible_whitespace_width(ws);
+      }
+      WordToken::LfNewLine | WordToken::CrlfNewLine => {
+        // the caller splits on '\n' before invoking this function, so
+        // paragraphs never contain newline tokens
+        debug_assert!(false, "unexpected newline token in wrap_paragraph");
+      }
     }
   }
+
+  if current_line.has_content() {
+    lines.push(current_line);
+  }
   lines
+}
+
+fn visible_whitespace_width(s: &str) -> usize {
+  s.chars()
+    .map(|c| unicode_width::UnicodeWidthChar::width(c).unwrap_or(1))
+    .sum()
 }
 
 fn are_collections_equal<T: PartialEq>(a: &[T], b: &[T]) -> bool {
@@ -486,6 +635,7 @@ mod test {
 
   use crate::ConsoleSize;
   use crate::ConsoleStaticText;
+  use crate::TextItem;
   use crate::VTS_CLEAR_CURSOR_DOWN;
   use crate::VTS_CLEAR_UNTIL_NEWLINE;
   use crate::VTS_MOVE_TO_ZERO_COL;
@@ -623,5 +773,47 @@ mod test {
       result,
       "~MOVE0~~CUP2~123~CLEAR_UNTIL_NEWLINE~~CDOWN1~~CLEAR_CDOWN~~CUP1~~MOVE0~"
     );
+  }
+
+  // Lots of text items must only render the bottom ones that fit on
+  // screen — see https://github.com/dsherret/console_static_text/issues/1
+  #[test]
+  fn truncates_many_items_to_console_height() {
+    let size = ConsoleSize {
+      cols: Some(20),
+      rows: Some(3),
+    };
+    let mut s = ConsoleStaticText::new(move || size);
+    let items: Vec<TextItem> = (0..1000)
+      .map(|i| TextItem::new_owned(format!("line {}", i)))
+      .collect();
+    let result = s.render_items_with_size(items.iter(), size).unwrap();
+    assert!(result.contains("line 997"));
+    assert!(result.contains("line 998"));
+    assert!(result.contains("line 999"));
+    assert!(!result.contains("line 996"));
+    assert!(!result.contains("line 0"));
+  }
+
+  // A single item with thousands of paragraphs should only render the ones
+  // that fit — the paragraph-level bottom-up pass skips wrapping for the rest.
+  #[test]
+  fn truncates_many_paragraphs_in_single_item() {
+    let size = ConsoleSize {
+      cols: Some(20),
+      rows: Some(3),
+    };
+    let mut s = ConsoleStaticText::new(move || size);
+    let text = (0..1000)
+      .map(|i| format!("line {}", i))
+      .collect::<Vec<_>>()
+      .join("\n");
+    let items = [TextItem::new_owned(text)];
+    let result = s.render_items_with_size(items.iter(), size).unwrap();
+    assert!(result.contains("line 997"));
+    assert!(result.contains("line 998"));
+    assert!(result.contains("line 999"));
+    assert!(!result.contains("line 996"));
+    assert!(!result.contains("line 0"));
   }
 }

--- a/src/word.rs
+++ b/src/word.rs
@@ -1,7 +1,7 @@
 #[derive(PartialEq, Debug)]
 pub enum WordToken<'a> {
   Word(&'a str),
-  WhiteSpace(char),
+  WhiteSpace(&'a str),
   LfNewLine,
   CrlfNewLine,
 }
@@ -10,14 +10,14 @@ impl<'a> WordToken<'a> {
   pub fn len(&self) -> usize {
     match self {
       WordToken::Word(text) => text.len(),
-      WordToken::WhiteSpace(c) => c.len_utf8(),
+      WordToken::WhiteSpace(text) => text.len(),
       WordToken::LfNewLine => 1,
       WordToken::CrlfNewLine => 2,
     }
   }
 }
 
-/// Takes a string and tokenizes it into words, whitespace, and newlines.
+/// Takes a string and tokenizes it into words, whitespace runs, and newlines.
 pub fn tokenize_words(text: &str) -> impl Iterator<Item = WordToken<'_>> {
   TokenIterator {
     text,
@@ -36,31 +36,49 @@ impl<'a> Iterator for TokenIterator<'a> {
   fn next(&mut self) -> Option<Self::Item> {
     let remaining_text = &self.text[self.current_index..];
     if remaining_text.is_empty() {
-      return None; // end of string
+      return None;
     }
 
-    let whitespace_or_newline_index =
-      find_whitespace_or_newline(remaining_text);
-    let token = if whitespace_or_newline_index == Some(0) {
-      let c = remaining_text.chars().next().unwrap();
-      match c {
-        '\n' => WordToken::LfNewLine,
-        // guaranteed by find_whitespace_or_newline to be \r\n
-        '\r' => WordToken::CrlfNewLine,
-        _ => WordToken::WhiteSpace(c),
+    let mut chars = remaining_text.char_indices();
+    let (_, first_char) = chars.next().unwrap();
+    let token = match first_char {
+      '\n' => WordToken::LfNewLine,
+      '\r'
+        if remaining_text.as_bytes().get(first_char.len_utf8())
+          == Some(&b'\n') =>
+      {
+        WordToken::CrlfNewLine
       }
-    } else {
-      let word_end_index =
-        whitespace_or_newline_index.unwrap_or(remaining_text.len());
-      let next = &remaining_text[..word_end_index];
-      WordToken::Word(next)
+      // a lone `\r` is treated as part of a word — match find_word_boundary below
+      c if c.is_whitespace() && c != '\r' => {
+        let end = find_whitespace_run_end(remaining_text);
+        WordToken::WhiteSpace(&remaining_text[..end])
+      }
+      _ => {
+        let end =
+          find_word_boundary(remaining_text).unwrap_or(remaining_text.len());
+        WordToken::Word(&remaining_text[..end])
+      }
     };
     self.current_index += token.len();
     Some(token)
   }
 }
 
-fn find_whitespace_or_newline(text: &str) -> Option<usize> {
+fn find_whitespace_run_end(text: &str) -> usize {
+  for (index, c) in text.char_indices() {
+    // newlines and lone `\r` end the whitespace run
+    match c {
+      '\n' => return index,
+      '\r' => return index,
+      c if !c.is_whitespace() => return index,
+      _ => {}
+    }
+  }
+  text.len()
+}
+
+fn find_word_boundary(text: &str) -> Option<usize> {
   let mut chars = text.char_indices().peekable();
   while let Some((index, c)) = chars.next() {
     match c {
@@ -87,7 +105,7 @@ mod tokenize_tests {
       result.collect::<Vec<_>>(),
       [
         WordToken::Word("hello"),
-        WordToken::WhiteSpace(' '),
+        WordToken::WhiteSpace(" "),
         WordToken::Word("world")
       ]
     );
@@ -117,10 +135,9 @@ mod tokenize_tests {
       result.collect::<Vec<_>>(),
       [
         WordToken::Word("hello"),
-        WordToken::WhiteSpace(' '),
+        WordToken::WhiteSpace(" "),
         WordToken::LfNewLine,
-        WordToken::WhiteSpace(' '),
-        WordToken::WhiteSpace(' '),
+        WordToken::WhiteSpace("  "),
         WordToken::Word("world")
       ]
     );
@@ -133,7 +150,7 @@ mod tokenize_tests {
       result.collect::<Vec<_>>(),
       [
         WordToken::Word("hello"),
-        WordToken::WhiteSpace('\t'),
+        WordToken::WhiteSpace("\t"),
         WordToken::Word("world")
       ]
     );
@@ -151,9 +168,9 @@ mod tokenize_tests {
     assert_eq!(
       result.collect::<Vec<_>>(),
       [
-        WordToken::WhiteSpace(' '),
+        WordToken::WhiteSpace(" "),
         WordToken::Word("hello"),
-        WordToken::WhiteSpace(' ')
+        WordToken::WhiteSpace(" ")
       ]
     );
   }
@@ -165,7 +182,7 @@ mod tokenize_tests {
       result.collect::<Vec<_>>(),
       [
         WordToken::Word("hello⌘"),
-        WordToken::WhiteSpace(' '),
+        WordToken::WhiteSpace(" "),
         WordToken::Word("⌘world")
       ]
     );


### PR DESCRIPTION
Console: 80 cols × 25 rows.

| Benchmark | N / len | main | optimized | speedup |
|---|---:|---:|---:|---:|
| **many_items** | 25 | 11.99 µs | 6.00 µs | **2.0x** |
| | 100 | 34.79 µs | 5.80 µs | **6.0x** |
| | 1,000 | 308 µs | 5.80 µs | **53x** |
| | 10,000 | 3.247 ms | 6.05 µs | **537x** |
| **single_item_many_paragraphs** | 25 | 9.99 µs | 4.45 µs | **2.2x** |
| | 100 | 26.29 µs | 4.99 µs | **5.3x** |
| | 1,000 | 252 µs | 11.39 µs | **22x** |
| | 10,000 | 2.485 ms | 131.5 µs | **18.9x** |
| **single_long_line** | 80 chars | 1.72 µs | 0.76 µs | **2.3x** |
| | 800 chars | 13.79 µs | 4.57 µs | **3.0x** |
| | 8,000 chars | 87.89 µs | 31.99 µs | **2.7x** |
| | 80,000 chars | 810 µs | 324.9 µs | **2.5x** |
| **wrapped_items** | 25 | 56.74 µs | 9.60 µs | **5.9x** |
| | 100 | 193.2 µs | 9.60 µs | **20x** |
| | 1,000 | 1.902 ms | 9.60 µs | **198x** |


Closes https://github.com/dsherret/console_static_text/issues/1